### PR TITLE
avoid possible misleading instructions

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -238,7 +238,9 @@ class ShopifySkeleton extends Yeoman {
     this.options.noAnims
       ? this.log(chalk.white((message)))
       : this.log(parrotSay(message + ' 🦄'))
-    this.log('PS: use npm run code to start')
+    this.options.npmInstall
+      ? this.log('PS: use ' + chalk.magenta('npm run code') + ' to start')
+      : this.log('PS: use ' + chalk.magenta('npm run start') + ' then ' + chalk.magenta('npm run code') + ' to start')
     return this.log('Love, Pixel2HTML')
   }
 }


### PR DESCRIPTION
users who for some reason choose not to run “npm install” in the yeoman generator script will get instructions at the end to “run npm run code to start” which will default in an error.

this update shows proper instructions based on whether “npm -i” ran or not during the generator script